### PR TITLE
Changed the URL handling to follow the specification from GRC.com.

### DIFF
--- a/android-sqrl/src/com/sqrl/android_sqrl/MainActivity.java
+++ b/android-sqrl/src/com/sqrl/android_sqrl/MainActivity.java
@@ -8,19 +8,22 @@ import java.util.List;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.NameValuePair;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.message.BasicNameValuePair;
 
-import com.github.dazoe.android.Ed25519;
-
-import eu.livotov.zxscan.ZXScanHelper;
-import android.os.AsyncTask;
-import android.os.Bundle;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.os.AsyncTask;
+import android.os.Bundle;
+import android.os.StrictMode;
 import android.util.Base64;
 import android.util.Log;
 import android.view.Menu;
@@ -30,11 +33,9 @@ import android.widget.EditText;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import org.apache.http.HttpResponse;
-import org.apache.http.HttpStatus;
-import org.apache.http.NameValuePair;
-import org.apache.http.impl.client.DefaultHttpClient;
-import org.apache.http.message.BasicNameValuePair;
+import com.github.dazoe.android.Ed25519;
+
+import eu.livotov.zxscan.ZXScanHelper;
 
 public class MainActivity extends Activity {
 	private TextView textView1 = null;
@@ -51,6 +52,9 @@ public class MainActivity extends Activity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);     
+        
+        StrictMode.ThreadPolicy policy = new StrictMode.ThreadPolicy.Builder().permitAll().build();
+        StrictMode.setThreadPolicy(policy);                
         
         textView1 = (TextView) findViewById(R.id.textView1);
         editText1 = (EditText) findViewById(R.id.editText1);
@@ -128,8 +132,7 @@ public class MainActivity extends Activity {
     	authReq = null;
     }
     
-    protected void onActivityResult(final int requestCode, final int resultCode, final Intent data)
-    {
+    protected void onActivityResult(final int requestCode, final int resultCode, final Intent data) {
     	// From loginAct
     	if (resultCode == RESULT_OK && requestCode == 54321) {
     		
@@ -205,7 +208,7 @@ public class MainActivity extends Activity {
     	HttpClient httpclient = new DefaultHttpClient();
 	    HttpPost httppost = new HttpPost(URL);
 	  
-	    try {
+	    try {	    	
 	        // Add data to post
 	        List<NameValuePair> nameValuePairs = new ArrayList<NameValuePair>(2);
 	        nameValuePairs.add(new BasicNameValuePair("message", message));
@@ -213,7 +216,6 @@ public class MainActivity extends Activity {
 	        nameValuePairs.add(new BasicNameValuePair("publicKey", publicKey));
 	    
 	        httppost.setEntity(new UrlEncodedFormEntity(nameValuePairs));	       	        
-	        
 	        HttpResponse response = httpclient.execute(httppost); // Execute HTTP Post Request
 	    	
 	        int status = response.getStatusLine().getStatusCode();
@@ -224,16 +226,19 @@ public class MainActivity extends Activity {
 	        	response.getEntity().writeTo(ostream);
 	    
 	        	String out = ostream.toString();
-	        	Log.v("web", out);
+	        	Log.v("web", "Return: "+out);
 	        	// See if the page returned "Verified"
 	        	if (out.contains("Verified")) {
 	        		Toast.makeText(context, "Verified", Toast.LENGTH_LONG).show(); // show the user	        		
-	        	}
-	        }  else {Log.v("web", "Connection not ok");}
+		        }
+       		}  else {
+       			Log.v("web", "Connection not ok: "+status);
+       			
+        	}
 	    } catch (ClientProtocolException e) {	
-	    	Log.e("web", "error");
+	    	Log.e("web", e.getMessage(), e);
 	    } catch (IOException e) {	  
-	    	Log.e("web", "error");
+	    	Log.e("web", e.getMessage(), e);
 	    }
     }
 }

--- a/android-sqrl/src/com/sqrl/android_sqrl/authRequest.java
+++ b/android-sqrl/src/com/sqrl/android_sqrl/authRequest.java
@@ -1,5 +1,8 @@
 package com.sqrl.android_sqrl;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+
 import android.util.Log;
 
 // Copyright © 2013 geir54
@@ -18,37 +21,75 @@ public class authRequest {
 		return isHTTPS;
 	}
 	
-	// The part thet should be signed
-	public String getURL() {
+	/**
+	 *  The part that should be signed.
+	 *  Removing the port number and login information from
+	 *  the url.
+	 */
+	public String getURL() {		
+		try {
+			URI u = new URI("http://"+URL.replaceAll("|", "/"));
+			StringBuilder sb = new StringBuilder();
+			sb.append(u.getHost());
+			sb.append(u.getPath());
+			sb.append("?");
+			sb.append(u.getQuery());		
+			
+			return sb.toString();
+		} catch (URISyntaxException e) {
+			Log.e("web", e.getMessage(), e);
+		}
 		return URL;
 	}
 	
-	public String getReturnURL() 
-	{
-		String retURL = URL.substring(0, URL.indexOf("?"));
-		if (isHTTPS) retURL =  "https://" + retURL; else
-			retURL =  "http://" + retURL;
-		Log.v("web", retURL);
+	/**
+	 * Return url should be the full url so we get the 
+	 * querystring to the server for processing. 
+	 */
+	public String getReturnURL() {
+		String retURL = (isHTTPS ? "https://" :  "http://") + URL;
+		Log.v("web", "ReturnURL: "+retURL);
 		return retURL;
 	}
 		
-	 // get domain form URL
-    public String getDomain() {    
-    	String domain  = URL.substring(0,URL.indexOf("/"));    	
+	/**
+	 * Get domain form URL. Use the URL without the port number and login information
+	 * to fetch the domain from. The scheme says to take everything
+	 * before pipe if available and turn in to domain. Otherwise
+	 * return the part before the slash.
+	 * 
+	 * @return
+	 */
+    public String getDomain() {
+    	String domain = null;
+    	if(URL.indexOf("|") > 0) {
+    		domain = URL.substring(0,URL.indexOf("|"));
+    	} else {
+    		domain = URL.substring(0,URL.indexOf("/"));
+    	}
+    	
+    	try {
+			URI u = new URI("http://"+domain);
+			StringBuilder sb = new StringBuilder();
+			sb.append(u.getHost());
+			sb.append(u.getPath());		
+	    	    	
+			Log.v("web", "Domain: "+sb.toString());
+			return sb.toString();
+    	} catch (Exception e) {
+    		Log.e("web", e.getMessage(), e);    		
+    	}
     	return domain;
     }
 	
 	  // remove the sqrl:// part from the URL and set isHTTPS
     private String removeScheme(String URL) {
-    	if (URL.substring(0, 1).compareTo("s") == 0) 
-    	{
+    	if (URL.substring(0, 1).compareTo("s") == 0) {
     		URL = URL.substring(7);
     		isHTTPS = true; 
-    	} 
-    	else  
-    	{
+    	} else {
     		URL = URL.substring(6);
-    		isHTTPS = false; 
+    		isHTTPS = false;
     	}    	
     	return URL;
     }


### PR DESCRIPTION
The specification states that domain is the path without sqrl:// before
either the slash or pipe sign. And we should not care about either port or
username and password in this string.

And when it comes to the url we call back to we need to send the
querystring so servers could retrieve data from the querystring that might
be needed for processing.

Also added the flag to permit all in strict mode to be able to run this
before we do the web calles in a background process.