### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ If you need help building the code or have questions come join us in #SQRL on ef
 
 The old ECC code has been replaced by https://github.com/dazoe/Android.Ed25519 and the code is now really fast
 
-####To build
+#### To build
 1. git submodule init
 2. git submodule update
 3. Import in eclipse and it should work


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
